### PR TITLE
Broadcast a "started" message after initialization

### DIFF
--- a/src/bg/main.js
+++ b/src/bg/main.js
@@ -180,6 +180,7 @@
           await include("/bg/Settings.js");
           Messages.addHandler(messageHandler);
 
+          await Messages.send("started");
           log("STARTED");
 
           this.devMode = (await browser.management.getSelf()).installType === "development";


### PR DESCRIPTION
Other extensions listening in on NoScript's messages (e.g. Torbutton) can take this message as an indication that it's now safe to send an `updateSettings` message to NoScript without immediately getting
clobbered by the configuration loader.

See https://trac.torproject.org/projects/tor/ticket/26520 for context.