### PR TITLE
Fix fallback scripts when ServiceWorkers are unavailable

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -85,13 +85,13 @@ ns.on("capabilities", () => {
   
   if (!ns.canScript) {
 
-    if (!!navigator.serviceWorker.controller) {
+    if ("serviceWorker" in navigator && navigator.serviceWorker.controller) {
       addEventListener("beforescriptexecute", e => e.preventDefault());
-        (async () => {
-          for (let r of await navigator.serviceWorker.getRegistrations()) {
-            await r.unregister();
-          }
-        })();
+      (async () => {
+        for (let r of await navigator.serviceWorker.getRegistrations()) {
+          await r.unregister();
+        }
+      })();
     }
 
     if (document.readyState !== "loading") onScriptDisabled();


### PR DESCRIPTION
ServiceWorkers are not available in private browsing mode (and can be
disabled otherwise via about:config), be sure to check its availability.
Otherwise fallback scripts are not invoked which prevents redirections
in `<noscript>` tags from being executed (as observed with t.co).