### PR TITLE
Bugfix: Chrome has not properly evaluated this

### DIFF
--- a/src/bg/main.js
+++ b/src/bg/main.js
@@ -142,7 +142,7 @@
 
     async fetchChildPolicy({url, contextUrl}, sender) {
       await ns.initializing;
-      return (messageHandler.fetchChildPolicy = messageHandler.fetchChildPolicySync)(...arguments);
+      return (this.fetchChildPolicy = this.fetchChildPolicySync)(...arguments);
     },
     fetchChildPolicySync({url, contextUrl}, sender) {
       let {tab, frameId} = sender;

--- a/src/bg/main.js
+++ b/src/bg/main.js
@@ -142,7 +142,7 @@
 
     async fetchChildPolicy({url, contextUrl}, sender) {
       await ns.initializing;
-      return (this.fetchChildPolicy = this.fetchChildPolicySync)(...arguments);
+      return (messageHandler.fetchChildPolicy = messageHandler.fetchChildPolicySync)(...arguments);
     },
     fetchChildPolicySync({url, contextUrl}, sender) {
       let {tab, frameId} = sender;

--- a/src/lib/Messages.js
+++ b/src/lib/Messages.js
@@ -21,7 +21,7 @@
       if (typeof f === "function") {
         let result;
         try {
-          result = f(msg, sender);
+          result = f.call(h, msg, sender);
         } catch (e) {
           error(e);
           exception = e;


### PR DESCRIPTION
Chrome had some problems with evaluating "this" correctly. Fixed this issue with directly referencing to `messageHandler`. Maybe need some further investigation, why this is not working with Chrome.