### PR TITLE
Update German translation

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -468,7 +468,7 @@
         "description": ""
     },
     "RevokeTemp": {
-        "message": "Temporäre Berechtigungen zurücksetzen",
+        "message": "Sämtliche temporären Berechtigungen aufheben",
         "description": ""
     },
     "RevokeTemp_accesskey": {
@@ -532,7 +532,7 @@
         "description": ""
     },
     "TempTrustPage": {
-        "message": "Alles auf dieser Seite vorübergehend als VERTRAUENSWÜRDIG einstellen",
+        "message": "Temporär allem auf dieser Seite VERTRAUEN",
         "description": ""
     },
     "TempTrustPage_accesskey": {
@@ -560,7 +560,7 @@
         "description": ""
     },
     "Trusted_temporary": {
-        "message": "Temporär VERTR.",
+        "message": "Temporär VERTRAUEN",
         "description": ""
     },
     "Trusted_permanent": {
@@ -692,7 +692,7 @@
         "description": ""
     },
     "allowTemp": {
-        "message": "$1 vorübergehend zulassen",
+        "message": "Temporär erlauben $1",
         "description": ""
     },
     "allowTempFrom": {


### PR DESCRIPTION
Since "vorübergehend" is too long for use in all fields, don't mix
and use "temporär" throughout to help understand which functions are
related.

Do not unnecessarily abbreviate "VERTR." because there is enough space.