### PR TITLE
Return null when webgl is not allowed

### DIFF
--- a/src/content/webglHook.js
+++ b/src/content/webglHook.js
@@ -80,7 +80,7 @@ if (typeof exportFunction === "function") ns.on("capabilities", event => {
             error(e);
           }
           notifyPage();
-          return {};
+          return null;
         }
         return getContext.call(this, type, ...rest);
       }, proto, {defineAs: "getContext"});


### PR DESCRIPTION
I see web sites supporting `Canvas.getContext("webgl")` returning `null` gracefully, compared with `getContext("webgl")` returning `{}`. In the second case, often web sites don't check the content of the returned object and assume they were given a valid context. The first case mirrors the behavior of Firefox (at least) when WebGL is disabled in `about:config`.

Google Maps is a primary example of this.