### PR TITLE
Remove references to `promsises` in RequestGuard.

### DIFF
--- a/src/bg/RequestGuard.js
+++ b/src/bg/RequestGuard.js
@@ -491,7 +491,6 @@ var RequestGuard = (() => {
 
       normalizeRequest(request);
       let result = ALLOW;
-      let promises = [];
       let headersModified = false;
 
       pending.headersProcessed = true;
@@ -532,11 +531,6 @@ var RequestGuard = (() => {
         }
       } catch (e) {
         error(e, "Error in onHeadersReceived", request);
-      }
-
-      promises = promises.filter(p => p instanceof Promise);
-      if (promises.length > 0) {
-        return Promise.all(promises).then(() => result);
       }
 
       return result;


### PR DESCRIPTION
This seems to be dead code, as `promises` is only ever instantiated as an empty list and then consumed. Nothing is ever added to it.