### PR TITLE
Add support for container tabs

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -823,6 +823,30 @@
   "TabGuard_optAllow": {
     "message": "Load normally"
   },
+  "DefaultContainerName": {
+    "message": "Default"
+  },
+  "enable_container_tabs_label": {
+    "message": "Enable support for container tabs"
+  },
+  "select_container_label": {
+    "message": "Choose a container:"
+  },
+  "copy_container_label": {
+    "message": "Copy permissions from container:"
+  },
+  "clear_container_label": {
+    "message": "Clear permissions for this container"
+  },
+  "forbid_replace_default_policy": {
+    "message": "Cannot replace the default policy."
+  },
+  "container_copy_warning": {
+    "message": "Copying permissions from \"$1\".\nAll site permissions for this container will be removed.\nThis action cannot be reverted.\nDo you want to continue?"
+  },
+  "container_clear_warning": {
+    "message": "All site permissions for this container will be removed.\nThis action cannot be reverted.\nDo you want to continue?"
+  },
   "LearnMoreLink": {
     "message": "Learn more…"
   },

--- a/src/bg/LifeCycle.js
+++ b/src/bg/LifeCycle.js
@@ -70,6 +70,7 @@ var LifeCycle = (() => {
       ));
 
       const policy = ns.policy.dry(true);
+      const contextStore = ns.contextStore.dry(true);
       const unrestrictedTabs = [...ns.unrestrictedTabs];
 
       if (policy.sites.temp.length == 0 &&
@@ -118,6 +119,7 @@ var LifeCycle = (() => {
       let {url} = tab;
       let {cypherText, key, iv} = await encrypt(JSON.stringify({
         policy,
+        contextStore,
         allSeen,
         unrestrictedTabs,
       }));
@@ -225,7 +227,7 @@ var LifeCycle = (() => {
             iv
           }, key, cypherText
         );
-        let {policy, allSeen, unrestrictedTabs} = JSON.parse(new TextDecoder().decode(encoded));
+        let {policy, contextStore, allSeen, unrestrictedTabs} = JSON.parse(new TextDecoder().decode(encoded));
         if (!policy) {
           throw new error("Ephemeral policy not found in survival tab %s!", tabId);
         }
@@ -233,6 +235,7 @@ var LifeCycle = (() => {
         destroyIfNeeded();
         if (ns.initializing) await ns.initializing;
         ns.policy = new Policy(policy);
+        ns.contextStore = new ContextStore(contextStore);
         await Promise.allSettled(
           Object.entries(allSeen).map(
             async ([tabId, seen]) => {
@@ -335,6 +338,17 @@ var LifeCycle = (() => {
         }
         if (changed) {
           await ns.savePolicy();
+        }
+        if (ns.contextStore) {
+          changed = false;
+          for (let k of Object.keys(ns.contextStore.policies)){
+            for (let p of ns.contextStore.policies[k].getPresets(presetNames)) {
+              if (callback(p)) changed = true;
+            }
+          }
+          if (changed) {
+            await ns.saveContextStore();
+          }
         }
       };
 

--- a/src/bg/RequestGuard.js
+++ b/src/bg/RequestGuard.js
@@ -390,7 +390,7 @@
 
         const wantsTemp = forcedTemp || checked.includes("temp");
         if (!contextMatch) {
-          const isDefault = perms === ns.policy.DEFAULT;
+          const isDefault = perms === policy.DEFAULT;
           perms = perms.clone();
           if (isDefault) perms.temp = wantsTemp;
           policy.set(key, perms);

--- a/src/bg/RequestGuard.js
+++ b/src/bg/RequestGuard.js
@@ -381,7 +381,9 @@
 
       const wantsContext = checked.includes("ctx");
 
-      let { siteMatch, contextMatch, perms } = ns.policy.get(key, contextUrl);
+      let cookieStoreId = sender.tab && sender.tab.cookieStoreId;
+      let policy = ns.getPolicy(cookieStoreId);
+      let { contextMatch, perms } = policy.get(key, contextUrl);
 
       if (!perms.capabilities.has(policyType) ||
           !contextMatch && wantsContext && ctxKey) {
@@ -391,7 +393,7 @@
           const isDefault = perms === ns.policy.DEFAULT;
           perms = perms.clone();
           if (isDefault) perms.temp = wantsTemp;
-          ns.policy.set(key, perms);
+          policy.set(key, perms);
           if (ctxKey && wantsContext) {
             perms.contextual.set(ctxKey, perms = perms.clone(/* noContext = */ true));
           }
@@ -399,6 +401,7 @@
         perms.temp = wantsTemp;
         perms.capabilities.add(policyType);
         await ns.savePolicy();
+        await ns.saveContextStore();
         await RequestGuard.DNRPolicy?.update();
       }
       return {enable: key};
@@ -645,13 +648,14 @@
   function intersectCapabilities(policyMatch, request) {
     const {cascadePermissions, cascadeRestrictions} = ns.sync;
     if (request.frameId !== 0 && cascadeRestrictions || request.type != "main_frame" && cascadePermissions) {
-      const {tabUrl, frameAncestors} = request;
+      const {tabUrl, frameAncestors, cookieStoreId} = request;
       const topUrl = tabUrl ||
         cascadePermissions && request.frameId == 0 && request.documentUrl ||
         frameAncestors && frameAncestors[frameAncestors?.length - 1]?.url ||
         TabCache.get(request.tabId)?.url;
       if (topUrl) {
-        return ns.policy.cascade(policyMatch, topUrl, {
+        const policy = ns.getPolicy(cookieStoreId);
+        return policy.cascade(policyMatch, topUrl, {
           permissions: cascadePermissions,
           restrictions: cascadeRestrictions,
         }).capabilities;
@@ -719,9 +723,10 @@
 
   function checkLANRequest(request) {
     if (!ns.isEnforced(request.tabId)) return ALLOW;
-    let {originUrl, url} = request;
+    let {originUrl, url, cookieStoreId} = request;
+    let policy = ns.getPolicy(cookieStoreId);
     if (originUrl && !Sites.isInternal(originUrl) && url.startsWith("http") &&
-      !ns.policy.can(originUrl, "lan", ns.policyContext(request))) {
+      !policy.can(originUrl, "lan", ns.policyContext(request))) {
       // we want to block any request whose origin resolves to at least one external WAN IP
       // and whose destination resolves to at least one LAN IP
       const {proxyInfo} = request; // see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo
@@ -756,9 +761,9 @@
 
     normalizeRequest(request);
 
-    let {tabId, type, url, originUrl} = request;
+    let {tabId, type, cookieStoreId, url, originUrl} = request;
 
-    const { policy } = ns;
+    const policy = ns.getPolicy(cookieStoreId);
 
     let previous = recent.find(request);
     if (previous) {
@@ -917,12 +922,12 @@
       let result = ALLOW;
 
       pending.headersProcessed = true;
-      let {url, tabId, responseHeaders, type} = request;
+      let {url, tabId, cookieStoreId, responseHeaders, type} = request;
       let isMainFrame = type === "main_frame";
       try {
         let capabilities;
         if (ns.isEnforced(tabId)) {
-          const { policy } = ns;
+          const policy = ns.getPolicy(cookieStoreId);
           const policyMatch = policy.get(url, ns.policyContext(request));
           let { perms } = policyMatch;
           if (isMainFrame) {
@@ -1013,13 +1018,14 @@
   async function injectPolicyScript(details) {
     await ns.initializing;
     if (ns.local.debug?.disablePolicyInjection) return '';  // DEV_ONLY
-    const {url, tabId, frameId, type} = details;
+    const {url, tabId, frameId, cookieStoreId, type} = details;
     const isTop = type == "main_frame";
     const domPolicy = await ns.computeChildPolicy(
       { url },
       {
         tab: { id: tabId, url: isTop ? url : null },
         frameId: isTop ? 0 : frameId,
+        cookieStoreId,
       }
     );
     domPolicy.navigationURL = url;

--- a/src/bg/Settings.js
+++ b/src/bg/Settings.js
@@ -100,6 +100,7 @@ var Settings = {
   async update(settings) {
     let {
       policy,
+      contextStore,
       xssUserChoices,
       tabId,
       unrestrictedTab,
@@ -179,6 +180,7 @@ var Settings = {
       // User is resetting options:
       // pick either current Tor Browser Security Level or default NoScript policy
       policy = ns.local.torBrowserPolicy || this.createDefaultDryPolicy();
+      contextStore = new ContextStore().dry();
       reloadOptionsUI = true;
     }
 
@@ -196,6 +198,12 @@ var Settings = {
     if (policy) {
       ns.policy = new Policy(policy);
       await ns.savePolicy();
+    }
+
+    if (contextStore) {
+      let newContextStore = new ContextStore(contextStore);
+      ns.contextStore = newContextStore
+      await ns.saveContextStore();
     }
 
     if (typeof unrestrictedTab === "boolean") {
@@ -245,6 +253,7 @@ var Settings = {
         knownCapabilities: Permissions.ALL,
       },
       policy: ns.policy.dry(),
+      contextStore: ns.contextStore.dry(),
       local: ns.local,
       sync: ns.sync,
       xssUserChoices: XSS.getUserChoices(),

--- a/src/bg/Settings.js
+++ b/src/bg/Settings.js
@@ -201,8 +201,14 @@ var Settings = {
     }
 
     if (contextStore) {
-      let newContextStore = new ContextStore(contextStore);
-      ns.contextStore = newContextStore
+      ns.contextStore = new ContextStore(contextStore);
+    }
+
+    if (policy && ns.contextStore) {
+      ns.contextStore.updatePresets(ns.policy);
+    }
+
+    if (contextStore || (policy && ns.contextStore)) {
       await ns.saveContextStore();
     }
 

--- a/src/bg/TabGuard.js
+++ b/src/bg/TabGuard.js
@@ -184,8 +184,10 @@ var TabGuard = (() => {
 
       // we suspect tabs which 1) have not been removed/discarded, 2) are restricted by policy, 3) can run JavaScript
       let suspiciousTabs = [...ties].map(TabCache.get).filter(
-        tab => tab && !tab.discarded && ns.isEnforced(tab.id) &&
-        (!(tab._isExplicitOrigin = tab._isExplicitOrigin || /^(?:https?|ftps?|file):/.test(tab.url)) || ns.policy.can(tab.url, "script"))
+        tab => tab && !tab.discarded && ns.isEnforced(tab.id) && (
+          !(tab._isExplicitOrigin = tab._isExplicitOrigin || /^(?:https?|ftps?|file):/.test(tab.url)) ||
+          ns.getPolicy(tab.cookieStoreId).can(tab.url, "script")
+        )
       );
 
       return suspiciousTabs.length > 0 && (async () => {
@@ -222,7 +224,7 @@ var TabGuard = (() => {
             }
             if (tab.url !== "about:blank") {
               debug(`Real origin for ${tab._externalUrl} (tab ${tab.id}) is ${tab.url}.`);
-              if (!ns.policy.can(tab.url, "script")) return;
+              if (!ns.getPolicy(tab.cookieStoreId).can(tab.url, "script")) return;
             }
           }
           if (!tab._contentType) {

--- a/src/bg/main.js
+++ b/src/bg/main.js
@@ -105,6 +105,18 @@
       }
     }
 
+    if (!ns.contextStore) { // it could have been already retrieved by LifeCycle
+      const contextStoreData = (await Storage.get("sync", "contextStore")).contextStore;
+      if (contextStoreData) {
+        ns.contextStore = new ContextStore(contextStoreData);
+        await ns.contextStore.updateContainers(ns.policy);
+      } else {
+        log("No container data found. Initializing new policies.")
+        ns.contextStore = new ContextStore();
+        await ns.contextStore.updateContainers(ns.policy);
+        await ns.saveContextStore();
+      }
+    }
 
     const {isTorBrowser} = ns.local;
     Sites.onionSecure = isTorBrowser;
@@ -177,10 +189,12 @@
       tabId = -1
     }) {
       const policy = ns.policy.dry(true);
+      const contextStore = ns.contextStore.dry(true);
       const seen = tabId !== -1 ? await ns.collectSeen(tabId) : null;
       const xssUserChoices = await XSS.getUserChoices();
       await Messages.send("settings", {
         policy,
+        contextStore,
         seen,
         xssUserChoices,
         local: ns.local,
@@ -281,6 +295,7 @@
   }
 
   let _policy = null;
+  let _contextStore = null;
 
   globalThis.ns = {
     running: false,
@@ -289,6 +304,11 @@
       RequestGuard.DNRPolicy?.update();
     },
     get policy() { return _policy; },
+    set contextStore(c) {
+      _contextStore = c;
+      RequestGuard.DNRPolicy?.update();
+    },
+    get contextStore() { return _contextStore; },
     local: null,
     sync: null,
     initializing: null,
@@ -322,9 +342,23 @@
       return !this.isEnforced(request.tabId) || this.policy.can(request.url, capability, this.policyContext(request));
     },
 
+    getPolicy(cookieStoreId){
+      if (
+        ns.contextStore &&
+        ns.contextStore.enabled &&
+        ns.contextStore.policies.hasOwnProperty(cookieStoreId)
+      ) {
+        let currentPolicy = ns.contextStore.policies[cookieStoreId];
+        debug("id", cookieStoreId, "has cookiestore", currentPolicy);
+        if (currentPolicy) return currentPolicy;
+      }
+      debug("default cookiestore", cookieStoreId);
+      return ns.policy;
+    },
+
     async computeChildPolicy({url, contextUrl}, sender) {
       await ns.initializing;
-      let { tab, origin, frameId, documentLifecycle } = sender;
+      let { tab, origin, frameId, cookieStoreId, documentLifecycle } = sender;
       const tabId = tab ? tab.id : -1;
 
       if (url == sender.url) {
@@ -341,7 +375,8 @@
           }
         }
       }
-      let policy = ns.policy;
+      if (!cookieStoreId && tab) cookieStoreId = tab.cookieStoreId;
+      let policy = ns.getPolicy(cookieStoreId);
       const {isTorBrowser} = ns.local;
       if (!policy) {
         console.log("Policy is null, initializing: %o, sending fallback.", ns.initializing);
@@ -449,6 +484,19 @@
       return this.policy;
     },
 
+    async saveContextStore() {
+      if (this.contextStore) {
+        await Promise.allSettled([
+          Storage.set("sync", {
+            contextStore: this.contextStore.dry()
+          }),
+          session.save(),
+          browser.webRequest.handlerBehaviorChanged()
+        ]);
+      }
+      return this.contextStore;
+    },
+
     openOptionsPage({tab, focus, hilite}) {
       const url = new URL(browser.runtime.getManifest().options_ui.page);
       if (tab !== undefined) {
@@ -510,5 +558,7 @@ if (!browser.windows) {
     log("All tabs closed: revoking temporary permissions.");
     ns.policy.revokeTemp();
     ns.savePolicy();
+    ns.contextStore.revokeTemp();
+    ns.saveContextStore();
   });
 }

--- a/src/bg/main.js
+++ b/src/bg/main.js
@@ -339,7 +339,10 @@
       return tab?.url || documentUrl || url;
     },
     requestCan(request, capability) {
-      return !this.isEnforced(request.tabId) || this.policy.can(request.url, capability, this.policyContext(request));
+      return (
+        !this.isEnforced(request.tabId) ||
+        ns.getPolicy(request.cookieStoreId).can(request.url, capability, this.policyContext(request))
+      );
     },
 
     getPolicy(cookieStoreId){

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,8 @@
       "webRequestFilterResponse",
       "webRequestFilterResponse.serviceWorkerScript",
       "dns",
-      "<all_urls>"
+      "<all_urls>",
+      "contextualIdentities"
   ],
   "host_permissions": [
       "<all_urls>"
@@ -62,6 +63,7 @@
       "/nscl/common/Sites.js",
       "/nscl/common/Permissions.js",
       "/nscl/common/Policy.js",
+      "/nscl/common/ContextStore.js",
       "/nscl/common/locale.js",
       "/nscl/common/Storage.js",
       "/nscl/common/include.js",

--- a/src/ui/options.css
+++ b/src/ui/options.css
@@ -114,6 +114,24 @@ fieldset:disabled {
   flex: 2 2;
 }
 
+.per-site-buttons {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-end;
+  width: 100%;
+  text-align: right;
+  margin: .5em 0 0 0;
+}
+#btn-clear-container {
+  margin-inline-start: .5em;
+}
+#copy-container {
+  margin-inline: .5em;
+}
+#copy-container-label {
+  margin-block: auto;
+}
+
 #policy {
   display: block;
   margin-top: .5em;
@@ -122,6 +140,12 @@ fieldset:disabled {
 }
 .hide, body:not(.debug) div.debug {
   display: none;
+}
+#context-store {
+  display: block;
+  margin-top: .5em;
+  min-height: 20em;
+  width: 90%;
 }
 
 #debug-tools {
@@ -135,6 +159,14 @@ fieldset:disabled {
 }
 
 #policy-error {
+  background: red;
+  color: #ff8;
+  padding: 0;
+  margin: 0;
+  font-weight: bold;
+}
+
+#context-store-error {
   background: red;
   color: #ff8;
   padding: 0;

--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -55,6 +55,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <span id="enforceOnRestart-opt">
       <input type="checkbox" id="opt-enforceOnRestart"><label for="opt-enforceOnRestart" id="lbl-enforceOnRestart">__MSG_EnforceOnRestart__</label>
     </span>
+    <span id="containers-opt">
+      <input type="checkbox" class="enforcement_required" id="opt-containers"><label for="opt-containers" id="lbl-containers">Enable support for container tabs</label>
+    </span>
   </div>
   <div class="opt-group not-tor">
     <label aria-expanded="false"><span>__MSG_behavior_label__</span><button class="modifier" id="current-behavior">__MSG_Custom__</button></label>
@@ -85,6 +88,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 <h3 class="flextabs__tab"><button class="flextabs__toggle enforcement_required">__MSG_SectionSitePermissions__</button></h3>
 <div class="flextabs__content">
+  <label for="select-container" id="select-container-label">Choose a container:</label>
+  <select name="select-container" id="select-container">
+    <option value="default">Default</option>
+  </select>
   <section class="sect-sites">
   <form id="form-newsite" class="browser-style" >
   <label id="newsite-label" for="newsite" accesskey="__MSG_WebAddress_accesskey__">__MSG_WebAddress__</label><input name="newsite" id="newsite" type="text" placeholder="[https://]noscript.net"
@@ -94,6 +101,15 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <div class="cssload-container">
   	   <div class="cssload-whirlpool"></div>
     </div>
+  </div>
+  <div class="per-site-buttons" id="per-site-buttons">
+    <label for="copy-container" id="copy-container-label">Copy permissions from container:</label>
+    <select name="copy-container" id="copy-container">
+      <option value=blank></option>
+      <option value="default">Default</option>
+    </select>
+    <div style="inline-size:0;margin-inline:.5em;border:1px solid #888"></div>
+    <button id="btn-clear-container">Clear permissions for this container</button>
   </div>
   </section>
 </div>
@@ -226,6 +242,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <div id="policy-error"></div>
     <textarea id="policy" class="browser-style">
     </textarea>
+    <div id="edit-context-store">
+      <label for="contextStore">ContextStore:</label>
+      <div id="context-store-error"></div>
+      <textarea id="context-store" class="browser-style">
+      </textarea>
+    </div>
   </div>
 
 </div>

--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -56,7 +56,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
       <input type="checkbox" id="opt-enforceOnRestart"><label for="opt-enforceOnRestart" id="lbl-enforceOnRestart">__MSG_EnforceOnRestart__</label>
     </span>
     <span id="containers-opt">
-      <input type="checkbox" class="enforcement_required" id="opt-containers"><label for="opt-containers" id="lbl-containers">Enable support for container tabs</label>
+      <input type="checkbox" class="enforcement_required" id="opt-containers"><label for="opt-containers" id="lbl-containers">__MSG_enable_container_tabs_label__</label>
     </span>
   </div>
   <div class="opt-group not-tor">
@@ -88,9 +88,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 <h3 class="flextabs__tab"><button class="flextabs__toggle enforcement_required">__MSG_SectionSitePermissions__</button></h3>
 <div class="flextabs__content">
-  <label for="select-container" id="select-container-label">Choose a container:</label>
+  <label for="select-container" id="select-container-label">__MSG_select_container_label__</label>
   <select name="select-container" id="select-container">
-    <option value="default">Default</option>
+    <option value="default">__MSG_DefaultContainerName__</option>
   </select>
   <section class="sect-sites">
   <form id="form-newsite" class="browser-style" >
@@ -103,13 +103,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
     </div>
   </div>
   <div class="per-site-buttons" id="per-site-buttons">
-    <label for="copy-container" id="copy-container-label">Copy permissions from container:</label>
+    <label for="copy-container" id="copy-container-label">__MSG_copy_container_label__</label>
     <select name="copy-container" id="copy-container">
       <option value=blank></option>
-      <option value="default">Default</option>
+      <option value="default">__MSG_DefaultContainerName__</option>
     </select>
     <div style="inline-size:0;margin-inline:.5em;border:1px solid #888"></div>
-    <button id="btn-clear-container">Clear permissions for this container</button>
+    <button id="btn-clear-container">__MSG_clear_container_label__</button>
   </div>
   </section>
 </div>

--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -246,14 +246,14 @@ document.querySelector("#version").textContent = _("Version",
   async function copyContainer() {
     cookieStoreId = containerSelect.value;
     if (cookieStoreId == "default") {
-      alert("Cannot replace the default policy.")
+      alert(_("forbid_replace_default_policy"))
       containerCopy.value = "blank";
       return;
     }
     let copyCookieStoreId = containerCopy.value;
     let copyContainerName = containerCopy.options[containerCopy.selectedIndex].text;
     let copyPolicy = await UI.getPolicy(copyCookieStoreId);
-    if (confirm(`Copying permissions from "${copyContainerName}".\n` + "All site permissions for this container will be removed.\nThis action cannot be reverted.\nDo you want to continue?")) {
+    if (confirm(_("container_copy_warning", copyContainerName))) {
       sitesUI.clear()
       currentPolicy = await UI.replacePolicy(cookieStoreId, new Policy(copyPolicy.dry(true)));
       await UI.updateSettings({policy, contextStore});
@@ -333,7 +333,7 @@ document.querySelector("#version").textContent = _("Version",
     }, true);
 
     document.querySelector("#btn-clear-container").addEventListener("click", async ev => {
-      if (confirm("All site permissions for this container will be removed.\nThis action cannot be reverted.\nDo you want to continue?")) {
+      if (confirm(_("container_clear_warning"))) {
         sitesUI.clear()
         currentPolicy.sites = Sites.hydrate({});
         await UI.updateSettings({policy, contextStore});

--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -227,6 +227,7 @@ document.querySelector("#version").textContent = _("Version",
 
   function updateContainersEnabled() {
     let containersEnabled = Boolean(contextStore.enabled && browser.contextualIdentities);
+    document.querySelector("#containers-opt").style.display = browser.contextualIdentities? "": "none";
     document.querySelector("#opt-containers").disabled = !browser.contextualIdentities;
     document.querySelector("#opt-containers").checked = contextStore.enabled;
     document.querySelector("#select-container").hidden = !containersEnabled;

--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -204,10 +204,7 @@ document.querySelector("#version").textContent = _("Version",
     let presetsUI = new UI.Sites(parent,
       {"DEFAULT": true, "TRUSTED": true, "UNTRUSTED": true});
     presetsUI.onChange = () => {
-      if (policy && contextStore) {  // contextStore presets always copy default policy's
-        contextStore.updatePresets(policy);
-        UI.updateSettings({policy, contextStore});
-      }
+      UI.updateSettings({policy, contextStore});
     }
 
     presetsUI.render([""]);

--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -29,6 +29,7 @@ document.querySelector("#version").textContent = _("Version",
   await UI.init();
 
   let policy = UI.policy;
+  let contextStore = UI.contextStore;
 
   // simple general options
 
@@ -37,7 +38,8 @@ document.querySelector("#version").textContent = _("Version",
   opt("global", o => {
     if (o) {
       policy.enforced = !o.checked;
-      UI.updateSettings({policy});
+      contextStore.setAll({"enforced": !o.checked});
+      UI.updateSettings({policy, contextStore});
     }
     let {enforced} = policy;
     let disabled = !enforced;
@@ -52,13 +54,24 @@ document.querySelector("#version").textContent = _("Version",
   opt("auto", o => {
     if (o) {
       policy.autoAllowTop = o.checked;
-      UI.updateSettings({policy});
+      contextStore.setAll({"autoAllowTop": o.checked});
+      UI.updateSettings({policy, contextStore});
     }
     return policy.autoAllowTop;
   });
 
   opt("cascadePermissions");
   opt("cascadeRestrictions");
+
+  opt("containers", async o => {
+    if (o) {
+      contextStore.enabled = o.checked;
+      await contextStore.updateContainers(policy);
+      UI.updateSettings({contextStore});
+    }
+    updateContainersEnabled();
+    return contextStore.enabled;
+  })
 
   opt("xss");
 
@@ -142,7 +155,10 @@ document.querySelector("#version").textContent = _("Version",
   opt("debug", "local", o => {
     let {checked} = o;
     document.body.classList.toggle("debug", checked);
-    if (checked) updateRawPolicyEditor();
+    if (checked) {
+      updateRawPolicyEditor();
+      updateRawContextStoreEditor();
+    }
   });
 
   UI.wireChoice("TabGuardMode");
@@ -187,6 +203,12 @@ document.querySelector("#version").textContent = _("Version",
     let parent = document.getElementById("presets");
     let presetsUI = new UI.Sites(parent,
       {"DEFAULT": true, "TRUSTED": true, "UNTRUSTED": true});
+    presetsUI.onChange = () => {
+      if (policy && contextStore) {  // contextStore presets always copy default policy's
+        contextStore.updatePresets(policy);
+        UI.updateSettings({policy, contextStore});
+      }
+    }
 
     presetsUI.render([""]);
     window.setTimeout(() => {
@@ -198,25 +220,94 @@ document.querySelector("#version").textContent = _("Version",
 
   // SITES UI
   let sitesUI = new UI.Sites(document.getElementById("sites"));
+  let containerSelect = document.querySelector("#select-container");
+  let containerCopy = document.querySelector("#copy-container");
+  var cookieStoreId = containerSelect.value;
+  var currentPolicy = await UI.getPolicy(cookieStoreId);
 
-  UI.onSettings.addListener(() => {
-    policy = UI.policy;
-    sitesUI.render(policy.sites);
+  function updateContainersEnabled() {
+    let containersEnabled = Boolean(contextStore.enabled && browser.contextualIdentities);
+    document.querySelector("#opt-containers").disabled = !browser.contextualIdentities;
+    document.querySelector("#opt-containers").checked = contextStore.enabled;
+    document.querySelector("#select-container").hidden = !containersEnabled;
+    document.querySelector("#select-container-label").hidden = !containersEnabled;
+    document.querySelector("#per-site-buttons").style.display = containersEnabled? "flex" : "none";
+  }
+  updateContainersEnabled();
+
+  async function changeContainer() {
+    cookieStoreId = containerSelect.value;
+    currentPolicy = await UI.getPolicy(cookieStoreId);
+    debug("container change", cookieStoreId, currentPolicy);
+    sitesUI.clear()
+    sitesUI.policy = currentPolicy;
+    sitesUI.render(currentPolicy.sites);
+  }
+  containerSelect.onchange = changeContainer;
+
+  async function copyContainer() {
+    cookieStoreId = containerSelect.value;
+    if (cookieStoreId == "default") {
+      alert("Cannot replace the default policy.")
+      containerCopy.value = "blank";
+      return;
+    }
+    let copyCookieStoreId = containerCopy.value;
+    let copyContainerName = containerCopy.options[containerCopy.selectedIndex].text;
+    let copyPolicy = await UI.getPolicy(copyCookieStoreId);
+    if (confirm(`Copying permissions from "${copyContainerName}".\n` + "All site permissions for this container will be removed.\nThis action cannot be reverted.\nDo you want to continue?")) {
+      sitesUI.clear()
+      currentPolicy = await UI.replacePolicy(cookieStoreId, new Policy(copyPolicy.dry(true)));
+      await UI.updateSettings({policy, contextStore});
+      sitesUI.policy = currentPolicy;
+      sitesUI.render(currentPolicy.sites);
+    }
+    containerCopy.value = "blank";
+  }
+  containerCopy.onchange = copyContainer;
+
+  var containers = [];
+  async function updateContainerOptions() {
+    let newContainers = [{cookieStoreId: "default", name: "Default"},];
+    let identities = browser.contextualIdentities && await browser.contextualIdentities.query({});
+    if (identities) {
+      identities.forEach(({cookieStoreId, name}) => {
+        newContainers.push({cookieStoreId, name});
+      })
+    }
+    if (JSON.stringify(newContainers) == JSON.stringify(containers)) return;
+    containers = newContainers;
+    var container_options = ""
+    for (var container of containers) {
+      container_options += "<option value=" + container.cookieStoreId + ">" + container.name + "</option>"
+    }
+    containerSelect.innerHTML = container_options;
+    containerSelect.value = cookieStoreId;
+    containerCopy.innerHTML = "<option value=blank></option>" + container_options;
+  }
+  containerSelect.onfocus = updateContainerOptions;
+  containerCopy.onfocus = updateContainerOptions;
+  if (contextStore.enabled) await updateContainerOptions();
+
+  UI.onSettings.addListener(async () => {
+    currentPolicy = await UI.getPolicy(cookieStoreId);
+    sitesUI.render(currentPolicy.sites);
   });
 
   {
     sitesUI.onChange = () => {
       if (UI.local.debug) {
         updateRawPolicyEditor();
+        updateRawContextStoreEditor();
       }
     };
-    sitesUI.render(policy.sites);
+    sitesUI.render(currentPolicy.sites);
 
     let newSiteForm = document.querySelector("#form-newsite");
     let newSiteInput = newSiteForm.newsite;
     let button = newSiteForm.querySelector("button");
     let canAdd = s => {
-      let match = policy.get(s).siteMatch;
+      let match = currentPolicy.get(s).siteMatch;
       return match === null || s.length > match.length;
     }
 
@@ -234,14 +325,23 @@ document.querySelector("#version").textContent = _("Version",
       let site = newSiteInput.value.trim();
       let valid = Sites.isValid(site);
       if (valid && canAdd(site)) {
-        policy.set(site, policy.TRUSTED);
-        UI.updateSettings({policy});
+        currentPolicy.set(site, currentPolicy.TRUSTED);
+        UI.updateSettings({policy, contextStore});
         newSiteInput.value = "";
-        sitesUI.render(policy.sites);
+        sitesUI.render(currentPolicy.sites);
         sitesUI.hilite(site);
         sitesUI.onChange();
       }
     }, true);
+
+    document.querySelector("#btn-clear-container").addEventListener("click", async ev => {
+      if (confirm("All site permissions for this container will be removed.\nThis action cannot be reverted.\nDo you want to continue?")) {
+        sitesUI.clear()
+        currentPolicy.sites = Sites.hydrate({});
+        await UI.updateSettings({policy, contextStore});
+        sitesUI.render(currentPolicy.sites);
+      }
+    });
 
     include("/ui/behavior.js");
   }
@@ -279,6 +379,7 @@ document.querySelector("#version").textContent = _("Version",
       try {
         UI.policy = policy = new Policy(JSON.parse(ed.value));
         UI.updateSettings({policy});
+        containerSelect.value = "default";
         sitesUI.render(policy.sites);
         ed.className = "";
         document.getElementById("policy-error").textContent = "";
@@ -286,6 +387,32 @@ document.querySelector("#version").textContent = _("Version",
         error(e);
         ed.className = "error";
         document.getElementById("policy-error").textContent = e.message;
+      }
+    }
+  }
+
+  function updateRawContextStoreEditor() {
+    if (!UI.local.debug) return;
+
+    // RAW POLICY EDITING (debug only)
+    if (!browser.contextualIdentities) {
+      document.querySelector("#edit-context-store").style.display = "none";
+      return;
+    }
+    let contextStoreEditor = document.getElementById("context-store");
+    contextStoreEditor.value = JSON.stringify(contextStore.dry(true), null, 2);
+    if (!contextStoreEditor.onchange) contextStoreEditor.onchange = (e) => {
+      let ed = e.currentTarget
+      try {
+        UI.contextStore = contextStore = new ContextStore(JSON.parse(ed.value));
+        UI.updateSettings({contextStore});
+
+        ed.className = "";
+        document.getElementById("context-store-error").textContent = "";
+      } catch (e) {
+        error(e);
+        ed.className = "error";
+        document.getElementById("context-store-error").textContent = e.message;
       }
     }
   }

--- a/src/ui/popup.css
+++ b/src/ui/popup.css
@@ -149,6 +149,18 @@ html:not(.mobile) #scrollable {
   display: none;
 }
 
+#top > .container-id {
+  text-align: center;
+  align-items: center;
+  display: flex;
+  margin: .2em;
+  margin-block: auto;
+  padding: .4em;
+  font-size: 1.2em;
+  border:1px solid lightgray;
+  border-radius: .3em;
+}
+
 .hider {
   background: var(--form-color1);
   box-shadow: inset 0 1px 3px #444;

--- a/src/ui/popup.html
+++ b/src/ui/popup.html
@@ -34,7 +34,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <a class="hider-close">×</a>
   </div>
   <div class="spacer"></div>
-  <div id="container-id" class="container-id">Default</div>
+  <div id="container-id" class="container-id">__MSG_DefaultContainerName__</div>
   <button aria-role="button" id="enforce" class="toggle icon"></button>
   <button aria-role="button" id="enforce-tab" class="toggle icon"></button>
   <button aria-role="button" id="temp-trust-page" class="toggle icon" title="__MSG_TempTrustPage__"></button>

--- a/src/ui/popup.html
+++ b/src/ui/popup.html
@@ -34,6 +34,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <a class="hider-close">×</a>
   </div>
   <div class="spacer"></div>
+  <div id="container-id" class="container-id">Default</div>
   <button aria-role="button" id="enforce" class="toggle icon"></button>
   <button aria-role="button" id="enforce-tab" class="toggle icon"></button>
   <button aria-role="button" id="temp-trust-page" class="toggle icon" title="__MSG_TempTrustPage__"></button>

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -106,6 +106,7 @@ addEventListener("unload", e => {
     } else {
       tabId = tab.id;
     }
+    let cookieStoreId = pageTab.cookieStoreId;
 
     if (!browser.windows) {
       // emulate popup over page by using blurred content as background
@@ -184,6 +185,19 @@ addEventListener("unload", e => {
       browser.tabs.onActivated.addListener(e => {
         if (e.tabId !== tabId) close();
       });
+    }
+
+    if (UI.contextStore && UI.contextStore.enabled && browser.contextualIdentities) {
+      try {
+        let containerName = (await browser.contextualIdentities.get(cookieStoreId)).name;
+        document.querySelector("#container-id").textContent = containerName;
+        debug("found container name", containerName, "for cookieStoreId", cookieStoreId);
+      } catch(err) {
+        document.querySelector("#container-id").textContent = "Default";
+        debug("no container for cookieStoreId", cookieStoreId, "error:", err.message);
+      }
+    } else {
+      document.querySelector("#container-id").style.visibility = 'hidden';
     }
 
     await include("/ui/toolbar.js");
@@ -386,7 +400,9 @@ addEventListener("unload", e => {
 
     let justDomains = !UI.local.showFullAddresses;
 
-    sitesUI = new UI.Sites(document.getElementById("sites"));
+    let policy = await UI.getPolicy(cookieStoreId);
+    debug("popup policy", policy);
+    sitesUI = new UI.Sites(document.getElementById("sites"), UI.DEF_PRESETS, policy);
 
     sitesUI.onChange = (row) => {
       const reload = sitesUI.anyPermissionsChanged()
@@ -423,7 +439,7 @@ addEventListener("unload", e => {
         typesMap
       } = sitesUI;
       typesMap.clear();
-      let policySites = UI.policy.sites;
+      let policySites = policy.sites;
       let domains = new Map();
       let protocols = new Set();
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -193,7 +193,7 @@ addEventListener("unload", e => {
         document.querySelector("#container-id").textContent = containerName;
         debug("found container name", containerName, "for cookieStoreId", cookieStoreId);
       } catch(err) {
-        document.querySelector("#container-id").textContent = "Default";
+        document.querySelector("#container-id").textContent = _("DefaultContainerName");
         debug("no container for cookieStoreId", cookieStoreId, "error:", err.message);
       }
     } else {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -58,6 +58,7 @@ var UI = (() => {
         "/nscl/common/Sites.js",
         "/nscl/common/Permissions.js",
         "/nscl/common/Policy.js",
+        "/nscl/common/ContextStore.js"
       ];
 
       this.mobile = UA.mobile;
@@ -69,7 +70,8 @@ var UI = (() => {
           async settings(m) {
             if (UI.tabId !== m.tabId) return;
             UI.policy = new Policy(m.policy);
-            UI.snapshot = UI.policy.snapshot;
+            UI.contextStore = new ContextStore(m.contextStore);
+            UI.snapshot = UI.policy.snapshot+UI.contextStore.snapshot;
             UI.seen = m.seen;
             UI.tabLess = m.tabLess;
             UI.unrestrictedTab = m.unrestrictedTab;
@@ -115,7 +117,7 @@ var UI = (() => {
         window.reload();
       }
       this.initialized = true;
-      debug("Imported", Policy);
+      debug("Imported", Policy, ContextStore);
     },
     async pullSettings() {
       try {
@@ -125,10 +127,12 @@ var UI = (() => {
         browser.runtime.reload();
       }
     },
-    async updateSettings({policy, xssUserChoices, unrestrictedTab, local, sync, reloadAffected, command}) {
+    async updateSettings({policy, contextStore, xssUserChoices, unrestrictedTab, local, sync, reloadAffected, command}) {
       if (policy) policy = policy.dry(true);
+      if (contextStore) contextStore = contextStore.dry(true);
       return await Messages.send("updateSettings", {
         policy,
+        contextStore,
         xssUserChoices,
         unrestrictedTab,
         local,
@@ -148,13 +152,41 @@ var UI = (() => {
 
     async revokeTemp(reloadAffected = false) {
       this.policy.revokeTemp();
+      this.contextStore.revokeTemp();
       if (this.isDirty(true)) {
-        await this.updateSettings({policy: this.policy, reloadAffected});
+        await this.updateSettings({policy: this.policy, contextStore: this.contextStore, reloadAffected});
+        await this.updateSettings({policy, contextStore, reloadAffected});
+      }
+    },
+
+    async getPolicy(cookieStoreId) {
+      await this.contextStore.updateContainers(this.policy);
+      if (this.contextStore.enabled && this.contextStore.policies.hasOwnProperty(cookieStoreId)) {
+        let currentPolicy = this.contextStore.policies[cookieStoreId];
+        debug("id", cookieStoreId, "has cookiestore", currentPolicy);
+        return currentPolicy;
+      } else {
+        debug("default cookiestore", cookieStoreId);
+        return this.policy;
+      }
+    },
+
+    async replacePolicy(cookieStoreId, policy) {
+      await this.contextStore.updateContainers(this.policy);
+      if (this.contextStore.policies.hasOwnProperty(cookieStoreId)) {
+        this.contextStore.policies[cookieStoreId] = policy;
+        debug("replaced id", cookieStoreId, "with policy", policy);
+        let currentPolicy = this.contextStore.policies[cookieStoreId];
+        return currentPolicy;
+      } else {
+        this.policy = policy;
+        debug("replaced default cookiestore", cookieStoreId, "with policy", policy);
+        return this.policy;
       }
     },
 
     isDirty(reset = false) {
-      let currentSnapshot = this.policy.snapshot;
+      let currentSnapshot = this.policy.snapshot+this.contextStore.snapshot;
       let dirty = currentSnapshot != this.snapshot;
       if (reset) this.snapshot = currentSnapshot;
       return dirty;
@@ -340,7 +372,7 @@ var UI = (() => {
 
   function fireOnChange(sitesUI, data) {
     if (UI.isDirty(true)) {
-      UI.updateSettings({policy: UI.policy});
+      UI.updateSettings({policy: UI.policy, contextStore: UI.contextStore});
       if (sitesUI.onChange) sitesUI.onChange(data, this);
     }
   }
@@ -419,10 +451,11 @@ var UI = (() => {
   const EXTRA_CAPS = ["x-load"];
 
   UI.Sites = class {
-    constructor(parentNode, presets = DEF_PRESETS) {
+    constructor(parentNode, presets = DEF_PRESETS, policy = null) {
       this.parentNode = parentNode;
+      this.policy = (policy)? policy : UI.policy;
       this.uiCount = UI.Sites.count = (UI.Sites.count || 0) + 1;
-      this.sites = UI.policy.sites;
+      this.sites = this.policy.sites;
       this.presets = presets;
       this.customizing = null;
       this.typesMap = new Map();
@@ -571,6 +604,11 @@ var UI = (() => {
 
       this.customize(null);
       this.sitesCount = 0;
+      this.sites = ({
+        trusted: [],
+        untrusted: [],
+        custom: {},
+      })
     }
 
     siteNeeds(site, type) {
@@ -617,7 +655,6 @@ var UI = (() => {
       let tempToggle = preset.parentNode.querySelector("input.temp");
 
       if (ev.type === "change") {
-        let { policy } = UI;
         if (!row._originalPerms) {
           row._originalPerms = row.perms.clone();
           Object.defineProperty(row, "permissionsChanged", {
@@ -631,7 +668,7 @@ var UI = (() => {
           if (!opt) return;
           let context = opt.value;
           if (context === "*") context = null;
-          ({ siteMatch, perms, contextMatch } = policy.get(siteMatch, context));
+          ({ siteMatch, perms, contextMatch } = this.policy.get(siteMatch, context));
           if (!context) {
             row._customPerms = perms;
           } else if (contextMatch !== context) {
@@ -650,8 +687,8 @@ var UI = (() => {
 
         let presetValue = preset.value;
         let policyPreset = presetValue.startsWith("T_")
-          ? policy[presetValue.substring(2)].tempTwin
-          : policy[presetValue];
+          ? this.policy[presetValue.substring(2)].tempTwin
+          : this.policy[presetValue];
 
         if (policyPreset && row.perms !== policyPreset) {
           row.perms = policyPreset;
@@ -669,7 +706,7 @@ var UI = (() => {
           row.perms = policyPreset;
           delete row._customPerms;
           if (siteMatch) {
-            policy.set(siteMatch, policyPreset);
+            this.policy.set(siteMatch, policyPreset);
           } else {
             this.customize(policyPreset, preset, row);
           }
@@ -686,7 +723,7 @@ var UI = (() => {
                 temp
               ));
             row.perms = perms;
-            policy.set(siteMatch, perms);
+            this.policy.set(siteMatch, perms);
             this.customize(perms, preset, row);
           }
         }
@@ -799,7 +836,7 @@ var UI = (() => {
           let selected = ctxSelect.querySelector("option:checked");
           ctxReset.disabled = !(selected?.value !== "*");
           ctxReset.onclick = () => {
-            let perms = UI.policy.get(row.siteMatch).perms;
+            let perms = this.policy.get(row.siteMatch).perms;
             perms.contextual.delete(row.contextMatch);
             fireOnChange(this, row);
             selected.previousElementSibling.selected = true;
@@ -1032,7 +1069,7 @@ var UI = (() => {
             site = site.site;
             context = site.context;
           }
-          let { siteMatch, perms, contextMatch } = UI.policy.get(site, context);
+          let { siteMatch, perms, contextMatch } = this.policy.get(site, context);
           this.append(site, siteMatch, perms, contextMatch);
           if (!hasTemp) hasTemp = perms.temp;
         }
@@ -1084,16 +1121,19 @@ var UI = (() => {
     }
 
     async tempTrustAll() {
-      let { policy } = UI;
       let changed = 0;
       for (let row of this.allSiteRows()) {
         if (row._preset === "DEFAULT") {
-          policy.set(row._site, policy.TRUSTED.tempTwin);
+          this.policy.set(row._site, this.policy.TRUSTED.tempTwin);
           changed++;
         }
       }
       if (changed && UI.isDirty(true)) {
-        await UI.updateSettings({ policy, reloadAffected: true });
+        await UI.updateSettings({
+          policy: UI.policy,
+          contextStore: UI.contextStore,
+          reloadAffected: true
+        });
       }
       return changed;
     }
@@ -1132,7 +1172,6 @@ var UI = (() => {
         contextMatch,
         perms
       );
-      const { policy } = UI;
       let row = this.rowTemplate.cloneNode(true);
       row.sitesCount = sitesCount;
 
@@ -1140,7 +1179,7 @@ var UI = (() => {
       try {
         url = new URL(site);
         if (siteMatch !== site && siteMatch === url.protocol) {
-          perms = policy.DEFAULT;
+          perms = this.policy.DEFAULT;
         }
       } catch (e) {
         if (/^(\w+:)\/*$/.test(site)) {
@@ -1163,7 +1202,7 @@ var UI = (() => {
       let { hostname } = url;
       let overrideDefault =
         site && url.protocol && site !== url.protocol
-          ? policy.get(url.protocol, contextMatch)
+          ? this.policy.get(url.protocol, contextMatch)
           : null;
       if (!overrideDefault?.siteMatch) overrideDefault = null;
 
@@ -1243,7 +1282,7 @@ var UI = (() => {
       let getPresetName = (perms) => {
         let presetName = "CUSTOM";
         for (let p of ["TRUSTED", "UNTRUSTED", "DEFAULT"]) {
-          let preset = policy[p];
+          let preset = this.policy[p];
           switch (perms) {
             case preset:
               presetName = p;
@@ -1296,8 +1335,8 @@ var UI = (() => {
             row
               .querySelector(`.presets input[value="${p}"]`)
               .parentNode.querySelector("input.temp").checked = true;
-            if (perms == policy.TRUSTED) {
-              perms = policy.TRUSTED.tempTwin;
+            if (perms == this.policy.TRUSTED) {
+              perms = this.policy.TRUSTED.tempTwin;
             }
           }
         }
@@ -1324,7 +1363,7 @@ var UI = (() => {
               w.title = title;
               w.textContent &&= label;
             }
-            row._customPerms = perms = UI.policy.cascade(policy.DEFAULT, this.mainUrl, {permissions: true});
+            row._customPerms = perms = UI.policy.cascade(this.policy.DEFAULT, this.mainUrl, {permissions: true});
           }
           preset.classList.toggle("canScript", perms.capabilities.has("script"));
         }
@@ -1348,9 +1387,8 @@ var UI = (() => {
       if (site !== row.siteMatch) {
         this.customize(null);
         let focused = document.activeElement;
-        let { policy } = UI;
-        policy.set(row.siteMatch, policy.DEFAULT);
-        policy.set(site, row.perms);
+        this.policy.set(row.siteMatch, this.policy.DEFAULT);
+        this.policy.set(site, row.perms);
         for (let r of this.allSiteRows()) {
           if (
             r !== row &&

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -1139,7 +1139,7 @@ var UI = (() => {
     }
 
     _customOrAuto(row) {
-      const { policy } = UI;
+      const policy = this.policy;
       const { perms, contextMatch, siteMatch } = row;
       const isAuto = policy.autoAllowTop && perms.temp &&
           contextMatch == siteMatch &&
@@ -1363,7 +1363,7 @@ var UI = (() => {
               w.title = title;
               w.textContent &&= label;
             }
-            row._customPerms = perms = UI.policy.cascade(this.policy.DEFAULT, this.mainUrl, {permissions: true});
+            row._customPerms = perms = this.policy.cascade(this.policy.DEFAULT, this.mainUrl, {permissions: true});
           }
           preset.classList.toggle("canScript", perms.capabilities.has("script"));
         }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -34,7 +34,7 @@ var UI = (() => {
         settingsListeners.add(l);
       },
       removeListener(l) {
-        settinsListeners.delete(l);
+        settingsListeners.delete(l);
       }
     },
 

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -71,7 +71,7 @@ var UI = (() => {
             if (UI.tabId !== m.tabId) return;
             UI.policy = new Policy(m.policy);
             UI.contextStore = new ContextStore(m.contextStore);
-            UI.snapshot = UI.policy.snapshot+UI.contextStore.snapshot;
+            UI.snapshot = `${UI.policy.snapshot}${UI.contextStore.snapshot}`;
             UI.seen = m.seen;
             UI.tabLess = m.tabLess;
             UI.unrestrictedTab = m.unrestrictedTab;
@@ -155,7 +155,6 @@ var UI = (() => {
       this.contextStore.revokeTemp();
       if (this.isDirty(true)) {
         await this.updateSettings({policy: this.policy, contextStore: this.contextStore, reloadAffected});
-        await this.updateSettings({policy, contextStore, reloadAffected});
       }
     },
 
@@ -163,10 +162,10 @@ var UI = (() => {
       await this.contextStore.updateContainers(this.policy);
       if (this.contextStore.enabled && this.contextStore.policies.hasOwnProperty(cookieStoreId)) {
         let currentPolicy = this.contextStore.policies[cookieStoreId];
-        debug("id", cookieStoreId, "has cookiestore", currentPolicy);
+        debug("id", cookieStoreId, "has cookiestore", currentPolicy); // DEV_ONLY
         return currentPolicy;
       } else {
-        debug("default cookiestore", cookieStoreId);
+        debug("default cookiestore", cookieStoreId); // DEV_ONLY
         return this.policy;
       }
     },
@@ -186,7 +185,7 @@ var UI = (() => {
     },
 
     isDirty(reset = false) {
-      let currentSnapshot = this.policy.snapshot+this.contextStore.snapshot;
+      const currentSnapshot = `${this.policy.snapshot}${this.contextStore.snapshot}`;
       let dirty = currentSnapshot != this.snapshot;
       if (reset) this.snapshot = currentSnapshot;
       return dirty;


### PR DESCRIPTION
This PR adds support for Firefox containers (#5, #166).

- Adds the option to use separate policies for each new container. Container policies initially copy the default policy. Container tab support is disabled by default.
- The current tab's container permissions can be edited from the NoScript popup.
- All containers are editable in the "NoScript Options" page. Container permissions can be copied between containers or cleared. Exporting and importing are supported.
- Adds a [ContextStore](https://github.com/aaronkollasch/nscl/blob/container-tabs/common/ContextStore.js) in nscl to store policies for each container.
- No changes to the filtering backend, except to make  `src/bg/RequestGuard.js` use the correct policy for each request.
- No changes to the UI if container tabs are disabled or the contextualIdentities API is not supported, e.g. in Chrome (except for an added option to enable/disable container tabs).