### PR TITLE
fix: #249 change accent color to lighter for better contrast in dark mode

### DIFF
--- a/src/common/themes.css
+++ b/src/common/themes.css
@@ -77,7 +77,7 @@
 
 .__NoScript_Theme__, .__NoScript_Theme__[data-theme="dark"] {
   color-scheme: dark;
-  --accent-color: #d12027;
+  --accent-color: #ffb366;
   --fg-color1: #ccc;
   --fg-color2: #fff;
   --text-color: #ddd;


### PR DESCRIPTION
Based on contrast color calculator, I change `--accent-color` variable to achieve passing minimal requirements for WCAG AAA for normal text and WCAG AA for graphical objects.

For combination `--accent-color` on `--bg-even-row` contrast ratio is 7:1
For combination `--accent-color` on `--bg-odd-row` contrast ratio is 9.14:1

That pass WCAG requirements. 