### PR TITLE
WIP: Implement Vim key bindings.

### DIFF
--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -830,8 +830,31 @@ var UI = (() => {
           break;
         case "Home":
           newRow = row;
+        case "KeyH":
+          dir = "previous";
+        case "KeyL":
+          const presets = row.querySelectorAll("input[class='preset']");
+          const currentIndex = [...presets].findIndex((p) => p.checked);
+          const step = dir === "next" ? 1 : -1;
+          const len = presets.length;
+
+          for (let i = 1; i < len; i++) {
+            // Limit nextIndex to [0, len).
+            const nextIndex = (currentIndex + len + i * step) % len;
+
+            // Skip disabled presets.
+            if (!presets[nextIndex].disabled) {
+              const nextPreset = presets[nextIndex];
+              nextPreset.focus();
+              nextPreset.click();
+              break;
+            }
+          }
+          break;
+        case "KeyK":
         case "ArrowUp":
           dir = "previous";
+        case "KeyJ":
         case "ArrowDown":
           if (!newRow) {
             this.customize(null);


### PR DESCRIPTION
Hi, first of all, thank you for this addon! I have been using it for many years now.

I recently searched for a possibility to control the NoScript permissions menu with Vim key bindings (i.e. h,j,k,l) instead of arrow keys.

As this is not possible yet, I have implemented a solution.
Are you generally open to have this merged upstream so other users can benefit from this as well?

I could only find issue #219 that seems related to this PR. Though I believe there might actually be some more users that could find this key binding useful.

---

If you are open to this PR, there might be a few changes still required, that's why i marked this as WIP for now.

As this implementation tries to mimic the native radio button movement, it can be different for only a few cases (e.g. when on the "Custom" button or in private mode).
I think this should be approached by either adjusting the new key bindings some more, merging both to the exact same behavior (with `ArrowLeft` and `ArrowRight` cases added), or ideally both.

Maybe there is even a better way to just have a setting that maps `ArrowLeft`/`ArrowRight` to `KeyH`/`KeyL`? I could not find one though.

_I have only tested this on Firefox 107/108 so far._