### PR TITLE
Fix of popup to use full window's width

### DIFF
--- a/src/common/themes.css
+++ b/src/common/themes.css
@@ -32,7 +32,7 @@
 
   --icon-size: 2.2em;
   --line-size: 1.5em;
-  --popup-size: 600px;
+  --popup-size: fill;
 
   --bg-preset-color: var(--form-color2);
   --bg-odd-row: var(--bg-color2);


### PR DESCRIPTION
Makes NoScript to use all the width of "Configure current page's permissions" window.

|main|![main](https://github.com/user-attachments/assets/ca48e603-290d-45cb-aa07-581bd3ae42ec)|
|---|---|
|commit|![commit](https://github.com/user-attachments/assets/63cc935e-bda3-41bd-8f5d-490c437de34a)|