### PR TITLE
[XSS] Fix harmless dots in URLs not being replaced

### DIFF
--- a/src/xss/InjectionChecker.js
+++ b/src/xss/InjectionChecker.js
@@ -388,7 +388,7 @@ XSS.InjectionChecker = (async () => {
       ) return true;
 
       expr = // dotted URL components can lead to false positives, let's remove them
-        expr.replace(this._removeDotsRx, this._removeDots)
+        expr.replace(this._removeDotsRx, this._removeDots.bind(this))
         .replace(this._arrayAccessRx, '_ARRAY_ACCESS_')
         .replace(/<([\w:]+)>[^</(="'`]+<\/\1>/g, '<$1/>') // reduce XML text nodes
         .replace(/<!--/g, '') // remove HTML comments preamble (see next line)


### PR DESCRIPTION
`InjectionChecker._removeDots` was called with `this` bound to `globalThis` instead of `InjectionChecker`, causing the dot-replace intended to reduce false positives to not work properly:

```js
_removeDots(p) {
  // this === [object DedicatedWorkerGlobalScope]
  // this._dotRx === undefined
  return p.replace(this._dotRx, '|');
},
...
expr.replace(this._removeDotsRx, this._removeDots)
```
Fixes #415 at least.

---

I considered doing simply
```diff
-expr.replace(this._removeDotsRx, this._removeDots)
+expr.replace(this._removeDotsRx, (p) => p.replace(this._dotRx, '|'))
```
but presumably there might be some performance benefit from defining a function only once.